### PR TITLE
Testing script with fake data. Testing coding for naturalism in belie…

### DIFF
--- a/funs/beliefscoreFun.R
+++ b/funs/beliefscoreFun.R
@@ -71,8 +71,8 @@ funBeliefScore <- function(df){
       # Naturalism  - NEEDS TESTING
 
       naturalism = case_when(
-        rowSums(across(all_of(snb_cols), ~grepl("Strongly Disagree |Moderately Disagree | Slightly Disagree", .))) > 0 ~ 1, 
-        TRUE ~ 0),
+        rowSums(across(all_of(snb_cols), ~. %in% c("Slightly Agree", "Moderately Agree", "Strongly Agree")) > 0) > 0 ~ 0, 
+        TRUE ~ 1),
       
       # Afterlife Existence
       afterlife_exist = snb_01,

--- a/survey_1/data_prep/survey_1_coding_scoring.qmd
+++ b/survey_1/data_prep/survey_1_coding_scoring.qmd
@@ -28,7 +28,7 @@ The functions loaded above do multiple things.
 
 `funBeliefCode` is a function to code our belief measures. This automates the scoring of the belief measures that are the same across the surveys. This just takes a dataframe as its only argument.
 
-`funBeliefCode` does a similar thing but scores variables and defines them according to their final definitions for analysis.
+`funBeliefScore` does a similar thing but scores variables and defines them according to their final definitions for analysis.
 
 `funCode` and `funCode2` are functions to **code** our survey responses, ready for scoring. funCode will score numerically, and funCode2 will create factors.
 
@@ -129,6 +129,8 @@ survey_1_scored <- survey1_coded %>%
 survey_1_scored <- funBeliefScore(survey_1_scored)
 
 # test <- survey_1_scored %>% select(issp_02, agnosticism_bin)  #example test line to check vars *before* select()
+
+# test_naturalism <- survey_1_scored %>% select(c(afterlife_exist:evil_eye), naturalism)  #example to test coding for naturalism in funBeliefScore. naturalism is defined as a dummy variable = 0 for cases where any of snb items (except 16, 17) are > 4 (neither agree nor disagree. Thus, rows where all cases are 4 should still be coded as 1, but this is not the case currently. See beliefscoreFun.R commits for potential solution
 ```
 
 ## Select Variables For Final Data


### PR DESCRIPTION
Code runs properly with fake data, though fake data only has 15 items for individualism-collectivism when the original scale has 16 items. Will need to make sure survey does have all 16. Using the current funBeliefScore function resulted in all naturalism values being 0. Definition of naturalism in codebook says this dummy should be 0 if any of the snb items are >4, so rows where all snb cases = 4 should have naturalism as 1. Tried some changes to funBeliefScore and it seems to work. However, in the fake data, all rows have at least one agreement response, with the exception of rows with 4 as the response for all snb items. So cannot assure that changes to the function would propelry code a row where answers are a combination of values (e.g., all 1s)